### PR TITLE
Access to full affine matrix registers / windowing registers

### DIFF
--- a/Lib/Chip/Unknown/Nintendo/GBA.hpp
+++ b/Lib/Chip/Unknown/Nintendo/GBA.hpp
@@ -325,6 +325,9 @@ constexpr ReadWriteField<Addr, unsigned, 14, 8> integer{};
 /// Sign
 constexpr ReadWriteField<Addr, unsigned, 15> sign{};
 
+/// Fixed-Point Value
+constexpr ReadWriteField<Addr, unsigned, 15, 0> value{};
+
 }
 namespace BG2PA = Bg2InternalParameterA;
 
@@ -340,6 +343,9 @@ constexpr ReadWriteField<Addr, unsigned, 14, 8> integer{};
 
 /// Sign
 constexpr ReadWriteField<Addr, unsigned, 15> sign{};
+
+/// Fixed-Point Value
+constexpr ReadWriteField<Addr, unsigned, 15, 0> value{};
 
 }
 namespace BG2PB = Bg2InternalParameterB;
@@ -357,6 +363,9 @@ constexpr ReadWriteField<Addr, unsigned, 14, 8> integer{};
 /// Sign
 constexpr ReadWriteField<Addr, unsigned, 15> sign{};
 
+/// Fixed-Point Value
+constexpr ReadWriteField<Addr, unsigned, 15, 0> value{};
+
 }
 namespace BG2PC = Bg2InternalParameterC;
 
@@ -372,6 +381,9 @@ constexpr ReadWriteField<Addr, unsigned, 14, 8> integer{};
 
 /// Sign
 constexpr ReadWriteField<Addr, unsigned, 15> sign{};
+
+/// Fixed-Point Value
+constexpr ReadWriteField<Addr, unsigned, 15, 0> value{};
 
 }
 namespace BG2PD = Bg2InternalParameterD;
@@ -429,6 +441,9 @@ constexpr ReadWriteField<Addr, unsigned, 14, 8> integer{};
 /// Sign
 constexpr ReadWriteField<Addr, unsigned, 15> sign{};
 
+/// Fixed-Point Value
+constexpr ReadWriteField<Addr, unsigned, 15, 0> value{};
+
 }
 namespace BG3PA = Bg2InternalParameterA;
 
@@ -444,6 +459,9 @@ constexpr ReadWriteField<Addr, unsigned, 14, 8> integer{};
 
 /// Sign
 constexpr ReadWriteField<Addr, unsigned, 15> sign{};
+
+/// Fixed-Point Value
+constexpr ReadWriteField<Addr, unsigned, 15, 0> value{};
 
 }
 namespace BG3PB = Bg2InternalParameterB;
@@ -461,6 +479,9 @@ constexpr ReadWriteField<Addr, unsigned, 14, 8> integer{};
 /// Sign
 constexpr ReadWriteField<Addr, unsigned, 15> sign{};
 
+/// Fixed-Point Value
+constexpr ReadWriteField<Addr, unsigned, 15, 0> value{};
+
 }
 namespace BG3PC = Bg2InternalParameterC;
 
@@ -476,6 +497,9 @@ constexpr ReadWriteField<Addr, unsigned, 14, 8> integer{};
 
 /// Sign
 constexpr ReadWriteField<Addr, unsigned, 15> sign{};
+
+/// Fixed-Point Value
+constexpr ReadWriteField<Addr, unsigned, 15, 0> value{};
 
 }
 namespace BG3PD = Bg2InternalParameterD;
@@ -527,6 +551,9 @@ using Addr = Register::Address<0x4000040, 0x00000000, 0x00000000, std::uint16_t>
 constexpr WriteOnlyField<Addr, unsigned, 7, 0> x2{};
 constexpr WriteOnlyField<Addr, unsigned, 15, 8> x1{};
 
+// TODO: figure out why writing 0 to upper half (x2) gives garbage value
+constexpr WriteOnlyField<Addr, unsigned, 15, 0> x{};
+
 }
 namespace WIN0H = Window0HorizontalExtent;
 
@@ -536,6 +563,7 @@ using Addr = Register::Address<0x4000042, 0x00000000, 0x00000000, std::uint16_t>
 
 constexpr WriteOnlyField<Addr, unsigned, 7, 0> x2{};
 constexpr WriteOnlyField<Addr, unsigned, 15, 8> x1{};
+constexpr WriteOnlyField<Addr, unsigned, 15, 0> x{};
 
 }
 namespace WIN1H = Window1HorizontalExtent;
@@ -546,6 +574,7 @@ using Addr = Register::Address<0x4000044, 0x00000000, 0x00000000, std::uint16_t>
 
 constexpr WriteOnlyField<Addr, unsigned, 7, 0> y2{};
 constexpr WriteOnlyField<Addr, unsigned, 15, 8> y1{};
+constexpr WriteOnlyField<Addr, unsigned, 15, 0> y{};
 
 }
 namespace WIN0V = Window0VerticalExtent;
@@ -556,6 +585,7 @@ using Addr = Register::Address<0x4000046, 0x00000000, 0x00000000, std::uint16_t>
 
 constexpr WriteOnlyField<Addr, unsigned, 7, 0> y2{};
 constexpr WriteOnlyField<Addr, unsigned, 15, 8> y1{};
+constexpr WriteOnlyField<Addr, unsigned, 15, 0> y{};
 
 }
 namespace WIN1V = Window1VerticalExtent;

--- a/Lib/Chip/Unknown/Nintendo/GBA.hpp
+++ b/Lib/Chip/Unknown/Nintendo/GBA.hpp
@@ -78,7 +78,7 @@ enum class GreenSwapModes {
     normal = 0,
     swap = 1
 };
-constexpr ReadWriteField<Addr, unsigned, 0> greenSwap{};
+constexpr ReadWriteField<Addr, GreenSwapModes, 0> greenSwap{};
 
 } // namespace GreenSwap
 
@@ -120,6 +120,18 @@ constexpr ReadOnlyField<Addr, unsigned, 7, 0> currentScanline{};
 }
 namespace VCOUNT = VerticalCounter;
 
+enum class BackgroundSizes : std::uint8_t {
+    reg32x32 = 0,
+    reg64x32 = 1,
+    reg32x64 = 2,
+    reg64x64 = 3,
+
+    aff16x16   = 0,
+    aff32x32   = 1,
+    aff64x64   = 2,
+    aff128x128 = 3
+};
+
 namespace Bg0Control {
 
 using Addr = Register::Address<0x4000008, 0x00000000, 0x00000000, std::uint16_t>;
@@ -143,7 +155,7 @@ constexpr ReadWriteField<Addr, unsigned, 12, 8> screenBaseBlock{};
 constexpr ReadWriteField<Addr, unsigned, 13> displayAreaOverflow{};
 
 /// Screen Size
-constexpr ReadWriteField<Addr, unsigned, 15, 14> screenSize{};
+constexpr ReadWriteField<Addr, BackgroundSizes, 15, 14> screenSize{};
 
 }
 namespace BG0CNT = Bg0Control;
@@ -171,10 +183,10 @@ constexpr ReadWriteField<Addr, unsigned, 12, 8> screenBaseBlock{};
 constexpr ReadWriteField<Addr, unsigned, 13> displayAreaOverflow{};
 
 /// Screen Size
-constexpr Register::FieldLocation<Addr, Register::maskFromRange(15, 14), Register::ReadWriteAccess, unsigned> screenSize{};
+constexpr ReadWriteField<Addr, BackgroundSizes, 15, 14> screenSize{};
 
 }
-namespace BG1CNT = Bg0Control;
+namespace BG1CNT = Bg1Control;
 
 namespace Bg2Control {
 
@@ -199,10 +211,10 @@ constexpr ReadWriteField<Addr, unsigned, 12, 8> screenBaseBlock{};
 constexpr ReadWriteField<Addr, unsigned, 13> displayAreaOverflow{};
 
 /// Screen Size
-constexpr ReadWriteField<Addr, unsigned, 15, 14> screenSize{};
+constexpr ReadWriteField<Addr, BackgroundSizes, 15, 14> screenSize{};
 
 }
-namespace BG2CNT = Bg0Control;
+namespace BG2CNT = Bg2Control;
 
 namespace Bg3Control {
 
@@ -227,10 +239,10 @@ constexpr ReadWriteField<Addr, unsigned, 12, 8> screenBaseBlock{};
 constexpr ReadWriteField<Addr, unsigned, 13> displayAreaOverflow{};
 
 /// Screen Size
-constexpr ReadWriteField<Addr, unsigned, 15, 14> screenSize{};
+constexpr ReadWriteField<Addr, BackgroundSizes, 15, 14> screenSize{};
 
 }
-namespace BG3CNT = Bg0Control;
+namespace BG3CNT = Bg3Control;
 
 namespace Bg0HorizOffset {
 


### PR DESCRIPTION
Concerning the affine matrix parameter registers, it would be useful to be able to access the entire register to be able to write full fixed-point parameters instead of having to go through the `fraction` and `integer` components.

For the windowing registers, I had noticed an issue where
`using namespace Kvasir::WIN0V;`
`apply(write(y2, start), write(y1, end));`
would result in a garbage value in the upper half of windowing vertical extent register and the expected value in the lower. To work around this I added a similar full-access field to the window extent registers and used as
`apply(write(y, (start << 8) | end));`
 I note that the windowing registers are write-only, perhaps I am not using the Kvasir functions properly? 

---

Also, this may be off-topic, but I was wondering if you had any copies of or material from your talk on [Embedded C++ on the GBA](https://legalizeadulthood.wordpress.com/2017/06/21/embedded-c-development-for-the-game-boy-advance-at-openwest-2017/)? It looked very interesting, but I could not find any captures on the OpenWest website or YouTube.